### PR TITLE
Fixes codemirror error, applied autofocus to component name

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,7 +11,7 @@
           div
             label.label-header Component Name
               small (camelCase -> kebab-case)
-            input(type="text", v-model="newComponent.name")
+            input(type="text", v-model="newComponent.name", "v-focus")
           hr
           div.flex.one
             div

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ import 'codemirror/keymap/sublime'
 import './assets/vendors/picnic.css'
 import './assets/vendors/picnic-plugins.css'
 import './assets/styles/styles.scss'
-console.log()
+
 Vue.use(VueCodeMirror)
 Vue.directive('focus', {
   // When the bound element is inserted into the DOM...

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@
 import Vue from 'vue'
 import App from './App'
 import VueCodeMirror from 'vue-codemirror'
+import 'codemirror/keymap/sublime'
 
 // Styles
 import './assets/vendors/picnic.css'


### PR DESCRIPTION
1. There was an error when the app is ran by using `npm run dev`. I figured out that I have to import 'codemirror/keymap/sublime' to fix it. (see https://github.com/surmon-china/vue-codemirror/issues/33)
2. Applied v-focus that is already exists to component name.
